### PR TITLE
Import status

### DIFF
--- a/data_api/api/models.py
+++ b/data_api/api/models.py
@@ -256,13 +256,13 @@ class BaseUtil(object):
         checkpoint = datetime.utcnow()
         if not ls:
             ls = LastSaved.create_for_org_and_collection(org, cls)
-            ls.last_started = checkpoint
-            ls.is_running = True
-            ls.save()
         elif ls.is_running:
             raise ImportRunningException('Import for model {} in org {} still pending!'.format(
                 cls.__name__, org.name,
             ))
+        ls.last_started = checkpoint
+        ls.is_running = True
+        ls.save()
         objs = cls.sync_temba_objects(org, ls, return_objs)
         ls.last_saved = checkpoint
         ls.is_running = False

--- a/data_api/api/models.py
+++ b/data_api/api/models.py
@@ -11,7 +11,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from mongoengine import connect, Document, StringField, BooleanField, ReferenceField, DateTimeField, IntField, \
     EmbeddedDocument, ListField, EmbeddedDocumentField, DictField, DynamicDocument, FloatField, DynamicField, \
-    MapField, ObjectIdField
+    MapField, ObjectIdField, DoesNotExist
 import pytz
 from rest_framework.authtoken.models import Token
 from temba_client.exceptions import TembaNoSuchObjectError, TembaException
@@ -111,6 +111,12 @@ class LastSaved(DynamicDocument):
     last_saved = DateTimeField()
     last_started = DateTimeField()
     is_running = BooleanField(default=False)
+
+    def get_org_display(self):
+        try:
+            return self.org.name
+        except DoesNotExist:
+            return 'Unknown or Deleted Org'
 
     @classmethod
     def get_for_org_and_collection(cls, org, collection_class):

--- a/data_api/api/models.py
+++ b/data_api/api/models.py
@@ -309,7 +309,7 @@ class EmbeddedUtil(object):
     @classmethod
     def instantiate_from_temba_list(cls, temba_list):
         obj_list = []
-        for temba in temba_list:
+        for temba in temba_list or []:
             obj_list.append(cls.instantiate_from_temba(temba))
         return obj_list
 

--- a/data_api/ui/templates/ui/base.html
+++ b/data_api/ui/templates/ui/base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ page_title|default:"RapidPro Data Warehouse" }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+{% block page_content %}}
+{% endblock %}
+</body>
+</html>

--- a/data_api/ui/templates/ui/base.html
+++ b/data_api/ui/templates/ui/base.html
@@ -3,9 +3,13 @@
 <head>
     <title>{{ page_title|default:"RapidPro Data Warehouse" }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% block page_head %}
+    {% endblock %}
 </head>
 <body>
-{% block page_content %}}
+{% block page_content %}
+{% endblock %}
+{% block page_js %}
 {% endblock %}
 </body>
 </html>

--- a/data_api/ui/templates/ui/import_org.html
+++ b/data_api/ui/templates/ui/import_org.html
@@ -9,6 +9,6 @@
     <table>
         {{ form.as_table }}
     </table>
-    <input type="submit"  value="Import Org"/>
+    <input type="submit" value="Import Org"/>
 </form>
-{% endblock %}}
+{% endblock %}

--- a/data_api/ui/templates/ui/import_org.html
+++ b/data_api/ui/templates/ui/import_org.html
@@ -1,10 +1,5 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Import your Org here</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-<body>
+{% extends 'ui/base.html' %}
+{% block page_content %}
 <h1>Import your Org Here</h1>
 {% if feedback %}
 <p>{{ feedback|safe }}</p>
@@ -14,7 +9,6 @@
     <table>
         {{ form.as_table }}
     </table>
-    <input type="submit" />
+    <input type="submit"  value="Import Org"/>
 </form>
-</body>
-</html>
+{% endblock %}}

--- a/data_api/ui/templates/ui/import_status.html
+++ b/data_api/ui/templates/ui/import_status.html
@@ -7,6 +7,7 @@
         <th>Model</th>
         <th>Last Saved</th>
         <th>Last Started</th>
+        <th>Delete</th>
     </tr>
     </thead>
     <tbody>
@@ -16,6 +17,12 @@
         <td>{{run.coll}}</td>
         <td>{{run.last_saved}}</td>
         <td>{{run.last_started}}</td>
+        <td>
+            <form action="{% url 'mark_completed' run.id %}" method="post">
+                {% csrf_token %}
+                <input type="submit" value="Mark Completed"/>
+            </form>
+        </td>
     </tr>
     {% endfor %}
     </tbody>

--- a/data_api/ui/templates/ui/import_status.html
+++ b/data_api/ui/templates/ui/import_status.html
@@ -1,0 +1,24 @@
+{% extends 'ui/base.html' %}
+{% block page_content %}
+<table>
+    <thead>
+    <tr>
+        <th>Org</th>
+        <th>Model</th>
+        <th>Last Saved</th>
+        <th>Last Started</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for run in pending_runs %}
+    <tr>
+        <td>{{run.get_org_display}}</td>
+        <td>{{run.coll}}</td>
+        <td>{{run.last_saved}}</td>
+        <td>{{run.last_started}}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+
+</table>
+{% endblock %}

--- a/data_api/ui/urls.py
+++ b/data_api/ui/urls.py
@@ -4,5 +4,6 @@ from . import views
 urlpatterns = patterns(
     '',
     url(r'^import_org/$', views.import_org_view),
-    url(r'^import_status/$', views.import_status),
+    url(r'^import_status/$', views.import_status, name='import_status'),
+    url(r'^import_status/mark_completed/(?P<last_saved_id>[\w]+)/$', views.mark_completed, name='mark_completed'),
 )

--- a/data_api/ui/urls.py
+++ b/data_api/ui/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = patterns(
     '',
     url(r'^import_org/$', views.import_org_view),
+    url(r'^import_status/$', views.import_status),
 )

--- a/data_api/ui/views.py
+++ b/data_api/ui/views.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.decorators import user_passes_test
+from django.core.urlresolvers import reverse
+from django.http import JsonResponse, HttpResponseRedirect
 from django.shortcuts import render
+from django.views.decorators.http import require_POST
 
 from data_api.api.models import LastSaved
 from data_api.api.utils import import_org
@@ -38,3 +41,13 @@ def import_status(request):
     return render(request, 'ui/import_status.html', {
         'pending_runs': pending_runs,
     })
+
+
+@user_passes_test(lambda u: u.is_superuser)
+@require_POST
+def mark_completed(request, last_saved_id):
+    ls = LastSaved.objects.get(id=last_saved_id)
+    assert ls.last_saved is None
+    ls.is_running = False
+    ls.save()
+    return HttpResponseRedirect(reverse('import_status'))

--- a/data_api/ui/views.py
+++ b/data_api/ui/views.py
@@ -37,9 +37,10 @@ def import_org_view(request):
 
 @user_passes_test(lambda u: u.is_superuser)
 def import_status(request):
-    pending_runs = LastSaved.objects.filter(is_running=True)
+    pending_runs = LastSaved.objects.filter(is_running=True).order_by('last_started')
     return render(request, 'ui/import_status.html', {
         'pending_runs': pending_runs,
+        'page_title': 'RapidPro: Import Status Page',
     })
 
 

--- a/data_api/ui/views.py
+++ b/data_api/ui/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import render
+
+from data_api.api.models import LastSaved
 from data_api.api.utils import import_org
 from data_api.ui.forms import OrgForm
 
@@ -25,5 +27,14 @@ def import_org_view(request):
 
     return render(request, 'ui/import_org.html', {
         'form': form,
-        'feedback': feedback
+        'feedback': feedback,
+        'page_title': 'RapidPro: Import Organization',
+    })
+
+
+@user_passes_test(lambda u: u.is_superuser)
+def import_status(request):
+    pending_runs = LastSaved.objects.filter(is_running=True)
+    return render(request, 'ui/import_status.html', {
+        'pending_runs': pending_runs,
     })


### PR DESCRIPTION
currently when an import crashes hard it leaves an artifact in the database that indicates that it is still currently running. this causes future imports to skip over that org/model to avoid conflicting / duplicate imports. but if the import actually crashed then we want to cancel that and restart the import.

this creates an (intentionally) minimal UI to be able to manually mark these as completed so that future imports can pick up on those models.

![image](https://user-images.githubusercontent.com/66555/38766085-43667706-3fcd-11e8-8bd6-f7eca3a630fe.png)
