### PR TITLE
support for ingesting messages using the archive api

### DIFF
--- a/data_api/api/ingestion.py
+++ b/data_api/api/ingestion.py
@@ -1,8 +1,12 @@
+import gzip
 import inspect
+import json
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
+from tempfile import NamedTemporaryFile
 
 import pytz
+import requests
 
 from data_api.api.exceptions import ImportRunningException
 from data_api.api.tasks import logger
@@ -227,3 +231,30 @@ def get_fetch_kwargs(fetch_method, checkpoint):
                 'after': checkpoint_time
             }
     return {}
+
+
+def ensure_timezone(checkpoint_time):
+    if checkpoint_time.tzinfo is None or checkpoint_time.tzinfo.utcoffset(checkpoint_time) is None:
+        checkpoint_time = pytz.utc.localize(checkpoint_time)
+    return checkpoint_time
+
+
+def download_archive_to_temporary_file(download_url):
+    f = NamedTemporaryFile(delete=False)
+    r = requests.get(download_url, stream=True)
+    with open(f.name, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk: # filter out keep-alive new chunks
+                f.write(chunk)
+    return f.name
+
+
+def iter_archive(filename):
+    """
+    Iterates through an archive file and yields the results as json
+    :param temp_file_name:
+    :return: an iterator of json wrapped objects
+    """
+    with gzip.open(filename, 'rb') as f:
+        for line in f.readlines():
+            yield json.loads(line)

--- a/data_api/api/models.py
+++ b/data_api/api/models.py
@@ -69,7 +69,7 @@ class CSVExport(models.Model):
 
 class Org(Document):
     api_token = StringField(required=True)
-    server = StringField(required=True, default=settings.DEFAULT_RAPIDPRO_SITE)
+    server = StringField(required=True, default=settings.RAPIDPRO_DEFAULT_SITE)
     is_active = BooleanField(default=False)
     name = StringField(required=True)
     country = StringField()

--- a/data_api/settings_common.py
+++ b/data_api/settings_common.py
@@ -86,7 +86,7 @@ TEMPLATES = [
 WSGI_APPLICATION = 'data_api.wsgi.application'
 
 RAPIDPRO_DEFAULT_SITE = 'https://app.rapidpro.io/'
-
+RAPIDPRO_USE_ARCHIVES = False
 
 LOG_FORMAT = '%(asctime)-15s %(message)s'
 

--- a/data_api/settings_common.py
+++ b/data_api/settings_common.py
@@ -85,7 +85,8 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'data_api.wsgi.application'
 
-DEFAULT_RAPIDPRO_SITE = 'https://app.rapidpro.io/'
+RAPIDPRO_DEFAULT_SITE = 'https://app.rapidpro.io/'
+
 
 LOG_FORMAT = '%(asctime)-15s %(message)s'
 

--- a/data_api/sql_views/migrations/0002_create_contact_view.py
+++ b/data_api/sql_views/migrations/0002_create_contact_view.py
@@ -13,6 +13,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('sql_views', '0001_initial'),
+        ('staging', '0010_auto_20180621_1539'),
     ]
 
     operations = [

--- a/data_api/staging/admin.py
+++ b/data_api/staging/admin.py
@@ -73,8 +73,8 @@ class CampaignEventAdmin(admin.ModelAdmin):
 
 
 class MessageAdmin(admin.ModelAdmin):
-    list_display = ['text', 'type', 'direction'] + ORG_MODEL_FIELDS
-    list_filter = ['type', 'direction'] + ORG_MODEL_FIELDS
+    list_display = ['text', 'type', 'direction', 'sent_on', 'visibility'] + ORG_MODEL_FIELDS
+    list_filter = ['type', 'direction', 'sent_on', 'visibility'] + ORG_MODEL_FIELDS
 
 
 class RunAdmin(admin.ModelAdmin):

--- a/data_api/staging/management/commands/delete_organization.py
+++ b/data_api/staging/management/commands/delete_organization.py
@@ -7,6 +7,13 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # Positional arguments
         parser.add_argument('org_id')
+        parser.add_argument(
+            '--noinput',
+            action='store_true',
+            dest='noinput',
+            default=False,
+            help='No prompts will be shown to user.',
+        )
 
     def handle(self, org_id, *args, **options):
 
@@ -16,13 +23,18 @@ class Command(BaseCommand):
             # try by api token
             org = Organization.objects.get(api_token=org_id)
         org_models = OrganizationModel.__subclasses__()
-        print('Are you sure you want to delete this organization: {} ({}) including the following models?'.format(
-            org.name, org.id
-        ))
+        noinput = options['noinput']
+        if noinput:
+            print('Deleting the following models:')
+        else:
+            print('Are you sure you want to delete this organization: {} ({}) including the following models?'.format(
+                org.name, org.id
+            ))
 
         for model in org_models:
             print('  {} {}s'.format(model.objects.filter(organization=org).count(), model.__name__))
-        if raw_input('y/N: ').lower().strip() == 'y':
+
+        if noinput or raw_input('y/N: ').lower().strip() == 'y':
             org.delete()
             print('org {} was deleted.'.format(org.name))
         else:

--- a/data_api/staging/models.py
+++ b/data_api/staging/models.py
@@ -40,7 +40,7 @@ class MappedManyToManyField(models.ManyToManyField):
 
 class Organization(models.Model):
     api_token = models.CharField(max_length=40)
-    server = models.CharField(max_length=100, default=settings.DEFAULT_RAPIDPRO_SITE)
+    server = models.CharField(max_length=100, default=settings.RAPIDPRO_DEFAULT_SITE)
     is_active = models.BooleanField(default=False)
     name = models.CharField(max_length=100)
     country = models.CharField(max_length=100, null=True, blank=True)

--- a/data_api/staging/models.py
+++ b/data_api/staging/models.py
@@ -385,7 +385,7 @@ class Message(OrganizationModel):
     rapidpro_collection = 'messages'
 
     def __unicode__(self):
-        return "%s - %s" % (self.text[:7], self.org_id)
+        return "%s - %s" % (self.text[:7], self.organization)
 
     @classmethod
     def get_checkpoint_for_folder(cls, org, folder):

--- a/data_api/staging/models.py
+++ b/data_api/staging/models.py
@@ -3,15 +3,17 @@ from collections import namedtuple
 
 from datetime import datetime
 
+import os
 import pytz
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models, transaction
-from temba_client.v2 import TembaClient
+from temba_client.v2 import TembaClient, Message as TembaMessage
 
 from data_api.api.exceptions import ImportRunningException
-from data_api.api.ingestion import RapidproAPIBaseModel, get_fetch_kwargs, SqlIngestionCheckpoint
+from data_api.api.ingestion import RapidproAPIBaseModel, get_fetch_kwargs, SqlIngestionCheckpoint, ensure_timezone, \
+    download_archive_to_temporary_file, iter_archive
 from data_api.api.models import logger
 
 """
@@ -393,13 +395,48 @@ class Message(OrganizationModel):
 
     @classmethod
     def sync_data_with_checkpoint(cls, org, checkpoint, return_objs=False):
+        initial_import = not cls.objects.filter(organization=org).exists()
+        if settings.RAPIDPRO_USE_ARCHIVES:
+            return cls._sync_from_archives(org, checkpoint, return_objs, initial_import)
+        else:
+            return cls._sync_from_apis(org, checkpoint, return_objs, initial_import)
+
+    @classmethod
+    def _sync_from_archives(cls, org, checkpoint, return_objs, initial_import):
+        temba_class = TembaMessage
+        archive_fetch_kwargs = {
+            'archive_type': 'message',
+            'period': 'monthly',
+        }
+        if checkpoint and checkpoint.exists() and checkpoint.get_last_checkpoint_time():
+            archive_fetch_kwargs['after'] = ensure_timezone(checkpoint.get_last_checkpoint_time())
+
+        def _iter_temba_objects():
+            archives = org.get_temba_client().get_archives(**archive_fetch_kwargs)
+            for archive in archives.all(retry_on_rate_exceed=True):
+                logger.info('downloading archives for {} ({})'.format(archive.archive_type, archive.start_date))
+                temp_file_name = download_archive_to_temporary_file(archive.download_url)
+                for temba_json in iter_archive(temp_file_name):
+                    try:
+                        yield temba_class.deserialize(temba_json)
+                    except:
+                        import json
+                        print(json.dumps(temba_json, indent=2))
+                        raise
+                # cleanup
+                os.remove(temp_file_name)
+
+        cls.create_from_temba_list(org, _iter_temba_objects(), return_objs, initial_import)
+
+
+    @classmethod
+    def _sync_from_apis(cls, org, checkpoint, return_objs, initial_import):
         fetch_method = cls.get_fetch_method(org)
         fetch_kwargs = get_fetch_kwargs(fetch_method, checkpoint)
         folders = [
             'inbox', 'flows', 'archived', 'outbox', 'incoming', 'sent',
         ]
         objs = []
-        initial_import = not cls.objects.filter(organization=org).exists()
         for folder in folders:
             logger.info('Syncing message folder {}'.format(folder))
             checkpoint = cls.get_checkpoint_for_folder(org, folder)

--- a/data_api/staging/models.py
+++ b/data_api/staging/models.py
@@ -411,7 +411,8 @@ class Message(OrganizationModel):
                 ))
             folder_kwargs = get_fetch_kwargs(fetch_method, checkpoint) or fetch_kwargs
             temba_objs = fetch_method(folder=folder, **folder_kwargs)
-            created_objs = cls.create_from_temba_list(org, temba_objs, return_objs,
+            temba_obj_generator = temba_objs.all(retry_on_rate_exceed=True)
+            created_objs = cls.create_from_temba_list(org, temba_obj_generator, return_objs,
                                                       is_initial_import=initial_import)
             if return_objs:
                 objs.extend(created_objs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pycrypto==2.6.1
 pymongo==3.5.1
 pytz==2017.3
 PyYAML==3.11
-rapidpro-python==2.2
+rapidpro-python==2.3
 raven==6.4.0
 redis==2.10.6
 requests==2.18.4


### PR DESCRIPTION
probably easiest reviewed by commit, everything but the last commit is prework to actually make the change.

@nicpottier I noticed that I'm getting different results when importing messages from archives versus directly using the message API. Do you have any immediate reaction to why that would be? It's a bit hard to stitch together the exact behavior but two observations:

1. The archives seem to import more unique messages that aren't imported in any of the folders I'm currently checking ('inbox', 'flows', 'archived', 'outbox', 'incoming', 'sent') in the regular API
2. Sometimes, the non-archives seem to import multiple copies of the same message - whereas the archives don't.