### PR TITLE
remove legacy raven setup

### DIFF
--- a/data_api/celery.py
+++ b/data_api/celery.py
@@ -3,27 +3,9 @@ import os
 import traceback
 from celery import Celery
 import sys
-import celery
-from django.conf import settings
-import raven
-from raven.contrib.celery import register_logger_signal, register_signal
 
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'data_api.settings')
-
-if settings.RAVEN_URL:
-    # see https://sentry.io/cory-zue/datauniceflabsorg/getting-started/python-celery/
-    class Celery(celery.Celery):
-
-        def on_configure(self):
-            client = raven.Client(settings.RAVEN_URL)
-
-            # register a custom filter to filter out duplicate logs
-            register_logger_signal(client)
-
-            # hook into the Celery error handler
-            register_signal(client)
-
 
 app = Celery('data_api')
 

--- a/data_api/settings_common.py
+++ b/data_api/settings_common.py
@@ -39,7 +39,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'raven.contrib.django.raven_compat',
     'anymail',
 
     'data_api.sql_views',
@@ -120,11 +119,6 @@ DATABASES = {
 }
 
 
-RAVEN_URL = None  # override WITH https://<key>:<secret>@app.getsentry.com/<project> to enable raven
-RAVEN_CONFIG = {
-    'dsn': 'https://<key>:<secret>@app.getsentry.com/<project>',
-}
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 
@@ -163,10 +157,6 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
-    'root': {
-        'level': 'WARNING',
-        'handlers': ['sentry'],
-    },
     'formatters': {
         'verbose': {
             'format': '%(levelname)s [%(asctime)s] %(module)s %(message)s'
@@ -181,10 +171,6 @@ LOGGING = {
         }
     },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
@@ -211,16 +197,6 @@ LOGGING = {
             'handlers': ['console'],
             'propagate': True,
             'level': 'DEBUG',
-        },
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
         },
     }
 }

--- a/data_api/settings_dev.py
+++ b/data_api/settings_dev.py
@@ -13,8 +13,6 @@ DATABASES = {
 }
 
 
-RAVEN_CONFIG = {}
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -57,16 +55,6 @@ LOGGING = {
             'handlers': ['console'],
             'propagate': True,
             'level': 'DEBUG',
-        },
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
         },
     }
 }

--- a/data_api/staging/tasks.py
+++ b/data_api/staging/tasks.py
@@ -1,15 +1,13 @@
 import logging
-import traceback
 from datetime import datetime
 from django.conf import settings
 from django.core.mail import mail_admins
 from retrying import retry
 from sentry_sdk import capture_exception
 from temba_client.exceptions import TembaConnectionError, TembaBadRequestError, TembaTokenError, \
-    TembaRateExceededError, TembaException
+    TembaRateExceededError
 from celery import task
 
-from data_api.staging.exceptions import ImportRunningException
 
 logging.basicConfig(format=settings.LOG_FORMAT)
 logger = logging.getLogger("tasks")

--- a/data_api/staging/tasks.py
+++ b/data_api/staging/tasks.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.mail import mail_admins
 from retrying import retry
+from sentry_sdk import capture_exception
 from temba_client.exceptions import TembaConnectionError, TembaBadRequestError, TembaTokenError, \
     TembaRateExceededError, TembaException
 from celery import task
@@ -51,18 +52,10 @@ def sync_latest_data(entities=None, orgs=None):
         for entity in entities:
             try:
                 fetch_entity(entity, org)
-            except ImportRunningException as e:
-                logger.error(str(e))
-                continue
-            except TembaException as e:
-                if settings.DEBUG:
-                    raise
-                logger.error("Temba is misbehaving: %s - No retry", str(e))
-                continue
             except Exception as e:
                 if settings.DEBUG:
                     raise
-                logger.error("Things are dead: %s - No retry", str(traceback.format_exc()))
+                capture_exception(e)
 
     task_duration = datetime.now() - start_time
     mail_admins('Finished RapidPro data sync in {} seconds'.format(task_duration.seconds), '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pycrypto==2.6.1
 pytz==2017.3
 PyYAML==3.11
 rapidpro-python==2.3
-raven==6.4.0
 redis==2.10.6
 requests==2.18.4
 retrying==1.3.3


### PR DESCRIPTION
https://app.clubhouse.io/unicefetools/story/11125/remove-port-raven-references-to-sentry-sdk

Also hopefully logs errors to sentry with a bit more granularity.