### PR TITLE
use serialize instead of __dict__ to capture nested objects

### DIFF
--- a/data_api/staging/ingestion.py
+++ b/data_api/staging/ingestion.py
@@ -141,7 +141,7 @@ class RapidproAPIBaseModel(object):
                         obj_list.append(obj)
             except Exception as e:
                 with configure_scope() as scope:
-                    scope.set_extra('temba_dict', temba.__dict__)
+                    scope.set_extra('temba_dict', temba.serialize())
                     capture_exception(e)
                     raise
             if len(chunk_to_save) > chunk_size:


### PR DESCRIPTION
currently sentry logs nested objects like this:

`campaign: <temba_client.v2.types.ObjectRef object at 0x7f8d14c9b7d0>`

This will unpack them so they show up like this:

```
campaign: {
 name: 'FAQ', 
 uuid: '78b79ffb-89ff-4dc9-a292-08767a4c8421'
}
```

which makes it easier to dig into issues related to referential errors (like [this one](https://sentry.io/organizations/unicef-jk/issues/1089997685/?project=1213635&query=is%3Aunresolved&statsPeriod=14d))